### PR TITLE
Slight refactoring

### DIFF
--- a/frontend/js/views/annotate-category.js
+++ b/frontend/js/views/annotate-category.js
@@ -280,18 +280,19 @@ define(["jquery",
             },
 
             /**
-             * Remove the given category from the views list
+             * Potentially remove the given category from the views list
              * @alias module:views-annotate-category.CategoryView#removeOne
              * @param {Category} Category from which the view has to be deleted
+             * @param newValue the new of the `deleted_at` attribute
              */
-            removeOne: function (delLabel) {
+            removeOne: function (delLabel, deleted) {
+                if (deleted == null) {
+                    return;
+                }
                 _.find(this.labelViews, function (labelView, index) {
                     if (delLabel === labelView.model) {
                         // this event fires when the "deleted_at" attribute of the label model changes
                         // ignore this event when the attribute is just being initialized
-                        if(labelView.model.changed.deleted_at == null) {
-                            return false;
-                        }
                         labelView.remove();
                         this.labelViews.splice(index, 1);
                         return true;


### PR DESCRIPTION
I would do it like this: The `removeOne` actually gets a second parameter (every event handler of a Backbone `change` event does), namely the new value for the attribute that is being watched. This way, we don't have to reach deep into the view. Also we can already bail out early; no need to look for the correct view, first. :)